### PR TITLE
Feat: Add <rp> tags for graceful ruby fallback

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -10,8 +10,8 @@ const addRubyTag = (editor: Editor, selected: string) => {
 		rubyTagMatch.index < cursor.ch &&
 		rubyTagMatch.index + rubyTagMatch[0].length > cursor.ch
 	);
-	let head = `${selected}<rt>`;
-	let tail = "</rt>";
+	let head = `${selected}<rp>(</rp><rt>`;
+	let tail = `</rt><rp>)</rp>`;
 	if (!alreadyInRuby) {
 		head = `<ruby>${head}`;
 		tail = `${tail}</ruby>`;

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "obsidian-furigana",
 	"name": "Furigana",
-	"version": "0.0.3",
+	"version": "0.0.4",
 	"minAppVersion": "0.11.0",
 	"description": "Helper plugin for furigana and <ruby>",
 	"author": "Koppa",


### PR DESCRIPTION
Title in Japanese: 機能: `<rp>`タグを追加し、ルビのグレースフルなフォールバックを実装

Title in Chinese: 功能: 添加 `<rp>` 标签以实现注音的优雅降级

-----

### (EN) English

This pull request enhances the ruby tag functionality by adding `<rp>` tags. This ensures graceful degradation, significantly improving the readability of the Markdown source in environments that do not support rendering ruby annotations.

#### **The Problem**

Previously, a ruby tag like `<ruby>大学<rt>daigaku</rt></ruby>` would appear as `大学daigaku` in plain text editors or source mode. This concatenation of the base text and its annotation makes the source file difficult to read.

#### **The Solution**

This PR modifies the tag generation logic to include `<rp>` (ruby parenthesis) tags. The generated markup is now:
`<ruby>大学<rp>(</rp><rt>daigaku</rt><rp>)</rp></ruby>`

This results in:

  - **In Obsidian's Preview Mode:** The annotation is rendered correctly above the text, and the parentheses within `<rp>` are hidden.
  - **In Plain Text / Non-supporting Environments:** The text is displayed as `大学(daigaku)`, which is perfectly readable.

#### **How to Test**

1.  Select a piece of text in the editor.
2.  Apply the "Add \<ruby\> tag" command via the context menu or command palette.
3.  **Verify (Source View):** Check that the generated source code includes the `<rp>(</rp>` and `<rp>)</rp>` tags.
4.  **Verify (Preview View):** Confirm that the ruby annotation renders correctly *without* showing the parentheses.
5.  **Verify (Plain Text):** Copy the raw text into a simple text editor and confirm the parentheses are visible, ensuring readability.

-----

### (JA) 日本語

このプルリクエストは、`<rp>`タグを追加することでルビタグ機能を強化するものです。これにより、ルビ注釈のレンダリングをサポートしない環境でもマークダウンソースの可読性を大幅に向上させ、グレースフル・デグラデーションを実現します。

#### **問題点**

以前は、`<ruby>大学<rt>だいがく</rt></ruby>`のようなルビタグは、プレーンテキストエディタやソースモードでは`大学だいがく`のように表示されていました。この原文と注釈の連結は、ソースファイルの可読性を損なっていました。

#### **解決策**

このPRでは、タグ生成ロジックを修正し、`<rp>`（ruby parenthesis）タグを含めるようにしました。生成されるマークアップは以下のようになります。
`<ruby>大学<rp>(</rp><rt>だいがく</rt><rp>)</rp></ruby>`

これにより、以下の結果が得られます。

  - **Obsidianのプレビューモードでは:** 注釈はテキストの上に正しくレンダリングされ、`<rp>`内の括弧は非表示になります。
  - **プレーンテキスト／非対応環境では:** テキストは`大学(だいがく)`のように表示され、完璧な可読性を保ちます。

#### **テスト方法**

1.  エディタでテキストを選択します。
2.  コンテキストメニューまたはコマンドパレットから「Add \<ruby\> tag」コマンドを適用します。
3.  **確認（ソースビュー）:** 生成されたソースコードに`<rp>(</rp>`と`<rp>)</rp>`タグが含まれていることを確認します。
4.  **確認（プレビュー）:** ルビ注釈が括弧なしで正しくレンダリングされることを確認します。
5.  **確認（プレーンテキスト）:** 素のテキストをシンプルなテキストエディタにコピーし、括弧が表示されて可読性が確保されていることを確認します。

-----

### (ZH) 中文

本 Pull Request 通过添加 `<rp>` 标签增强了 `<ruby>` 注音功能。这确保了优雅降级（graceful degradation），显著提高了 Markdown 源代码在不支持注音渲染环境下的可读性。

#### **问题背景**

在此之前，像 `<ruby>大学<rt>dà xué</rt></ruby>` 这样的注音标签在纯文本编辑器或源代码模式下会显示为 `大学dà xué`。原文和注音的直接拼接使得源文件难以阅读。

#### **解决方案**

本次提交修改了标签的生成逻辑，加入了 `<rp>` (ruby parenthesis) 标签。现在生成的 HTML 标记如下：
`<ruby>大学<rp>(</rp><rt>dà xué</rt><rp>)</rp></ruby>`

这将带来以下效果：

  - **在 Obsidian 预览模式下：** 注音会正确地渲染在文字上方，而 `<rp>` 标签内的括号会被隐藏。
  - **在纯文本/不支持的环境下：** 文本会显示为 `大学(dà xué)`，从而保持了完美的可读性。

#### **如何测试**

1.  在编辑器中选中文本。
2.  通过右键菜单或命令面板应用 “Add \<ruby\> tag” 命令。
3.  **验证 (源代码视图):** 检查生成的源代码是否包含了 `<rp>(</rp>` 和 `<rp>)</rp>` 标签。
4.  **验证 (预览视图):** 确认注音渲染正确，且没有显示括号。
5.  **验证 (纯文本):** 将生成的原始文本复制到记事本等纯文本编辑器中，确认括号可见，保证了可读性。