### PR TITLE
Add new command to strip ruby/rt tags and copy plain text

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ Obsidian Furigana
 
 Add a command to mark `<ruby>selected text...<rt></rt></ruby>` for selected text.
 
+Adds a second command to copy the "plain" text to clipboard (by removing any `ruby` and `rt` tags, only preserving `ruby` sections).
+
 **TODO**: auto convert kanji to higakana
 
 ## Screenshot and usage

--- a/main.ts
+++ b/main.ts
@@ -21,6 +21,26 @@ const addRubyTag = (editor: Editor, selected: string) => {
 	editor.setCursor({ line, ch: ch - tail.length });
 };
 
+const copyWithoutRuby = (editor: Editor) => {
+	let text = editor.getSelection();
+
+	// If no text is selected, use the current line
+	if (!text || text.trim() === "") {
+		const cursor = editor.getCursor();
+		text = editor.getLine(cursor.line);
+	}
+
+	text = text.replace(/<rt>.*?<\/rt>/g, "");
+	text = text.replace(/<rp>.*?<\/rp>/g, "");
+	text = text.replace(/<\/?ruby>/g, "");
+
+	navigator.clipboard
+		.writeText(text)
+		.catch((err) => {
+			console.error("Failed to copy text to clipboard:", err);
+		});
+};
+
 export default class AliasPlugin extends Plugin {
 	async onload() {
 		this.registerEvent(
@@ -50,6 +70,21 @@ export default class AliasPlugin extends Plugin {
 				}
 				return true;
 			}
+		});
+		this.addCommand({
+			id: "copy-without-ruby",
+			name: "Copy text or line without <ruby> tags to clipboard",
+			checkCallback: (checking: boolean) => {
+				let view = this.app.workspace.getActiveViewOfType(MarkdownView);
+				if (!view) {
+					return false;
+				}
+				const editor = view.editor;
+				if (!checking) {
+					copyWithoutRuby(editor);
+				}
+				return true;
+			},
 		});
 	}
 

--- a/main.ts
+++ b/main.ts
@@ -58,6 +58,7 @@ export default class AliasPlugin extends Plugin {
 		this.addCommand({
 			id: 'add-ruby',
 			name: 'Add <ruby> tag for selected text',
+			icon: 'gem',
 			checkCallback: (checking: boolean) => {
 				let view = this.app.workspace.getActiveViewOfType(MarkdownView);
 				if (!view) {
@@ -74,6 +75,7 @@ export default class AliasPlugin extends Plugin {
 		this.addCommand({
 			id: "copy-without-ruby",
 			name: "Copy text or line without <ruby> tags to clipboard",
+			icon: 'scissors-line-dashed',
 			checkCallback: (checking: boolean) => {
 				let view = this.app.workspace.getActiveViewOfType(MarkdownView);
 				if (!view) {


### PR DESCRIPTION
Thanks for this wonderful plugin!

This PR adds a second command to copy the selected text (or current line) to clipboard by "removing" `ruby` and `rt` and `rp` tags and keeping just the text inside `ruby`. Therefore, running this command on this line:
```
<ruby>田中<rt>タナカ</rt></ruby>さんが<ruby>好<rt>す</rt></ruby>きです
```
copies the following to the clipboard:
```
田中さんが好きです
```

<img width="1462" height="410" alt="Screenshot 2025-07-26 at 7 14 44 PM" src="https://github.com/user-attachments/assets/d3a3c09d-ab2b-4607-84bd-d229ab56aa3c" />

Would this be of interest?

**Edit** Tested on both macOS desktop and iOS mobile, works fine!

**Edit 2** Second commit adds icons to the two commands, which you can see in mobile here:


![Original ruby command has a "gem" icon and the new copy command has a "scissors cutting along a dotted line" icon](https://github.com/user-attachments/assets/0ef48e38-aaaf-4919-ad8d-7c01e4bb3f22)


